### PR TITLE
put both tests into a single executables stanza to avoid errors

### DIFF
--- a/src/dns_forward_test/dune
+++ b/src/dns_forward_test/dune
@@ -1,10 +1,6 @@
 (executables
- (names test)
- (libraries dns_forward dns_forward_lwt_unix lwt-dllist logs logs.fmt alcotest))
-
-(executable
-  (name test_fake)
-  (libraries dns_forward dns_forward_lwt_unix lwt-dllist logs logs.fmt alcotest mirage-mtime.mock))
+ (names test test_fake)
+ (libraries dns_forward dns_forward_lwt_unix lwt-dllist logs logs.fmt alcotest mirage-mtime.mock))
 
 (rule
  (alias  runtest)


### PR DESCRIPTION
should solve https://github.com/moby/vpnkit/pull/646#issuecomment-3232670681 (at least locally with `dune build @install @check @runtest`)